### PR TITLE
Support secure storage 8.0.0 and up

### DIFF
--- a/flutter/plugins/secure_storage_local_storage_inspector/CHANGELOG.md
+++ b/flutter/plugins/secure_storage_local_storage_inspector/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.6.0
+
+* Support secure storage 8.0.x
+
 ## 0.5.0
 
 * Support secure storage 7.0.x 

--- a/flutter/plugins/secure_storage_local_storage_inspector/pubspec.yaml
+++ b/flutter/plugins/secure_storage_local_storage_inspector/pubspec.yaml
@@ -1,6 +1,6 @@
 name: secure_storage_local_storage_inspector
 description: Local storage inspector bindings for secure storage based storage
-version: 0.5.0
+version: 0.6.0
 homepage: https://github.com/NicolaVerbeeck/flutter_local_storage_inspector
 
 funding:
@@ -13,7 +13,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  flutter_secure_storage: ^7.0.0
+  flutter_secure_storage: ^8.0.0
   storage_inspector: ^0.3.0
   uuid: ^3.0.6
 


### PR DESCRIPTION
I don't believe there are any (breaking) changes to the plugin interface, so it should work just fine. I bumped the version of the `secure_storage_local_storage_inspector` to `0.6.0` too.

https://pub.dev/packages/flutter_secure_storage/changelog#800